### PR TITLE
Fix value retrieval to use JSON.stringify instead of toString

### DIFF
--- a/easy-storage/v2/dist/easy-storage.js
+++ b/easy-storage/v2/dist/easy-storage.js
@@ -59,7 +59,7 @@ class EasyStorage {
   getKey(key, default_value = "") {
     debugLog(3, `Retrieving key: ${key}`);
     if (Object.prototype.hasOwnProperty.call(this.#content_obj, key)) {
-      const value = this.#content_obj[key].toString();
+      const value = JSON.stringify(this.#content_obj[key]);
       debugLog(2, `Found value for key '${key}': ${value}`);
       return value;
     }


### PR DESCRIPTION
Fix object retrieval by replacing toString with JSON.stringify

### Summary
This PR fixes an issue in the EasyStorage module where values were being retrieved using `.toString()`, which results in `[object Object]`. This approach leads to incorrect formatting or runtime errors when the value is an object.

### Problem
Using `toString()` on an object results in `[object Object]`, which is not useful for storage or debugging. Moreover, it can throw an error for certain object types that lack a proper `toString()` implementation.

### Fix
Replaced `.toString()` with `JSON.stringify(content[key])` to ensure:
- Object values are correctly serialized
- Consistent and reliable value formatting for all data types

### Impact
- Prevents runtime errors when retrieving object values
- Improves data consistency and reliability
